### PR TITLE
add short came to CRD

### DIFF
--- a/deploy/crds/lyra_v1alpha1_workflow_crd.yaml
+++ b/deploy/crds/lyra_v1alpha1_workflow_crd.yaml
@@ -9,6 +9,8 @@ spec:
     listKind: WorkflowList
     plural: workflows
     singular: workflow
+    shortNames:
+    - wf
   scope: Namespaced
   version: v1alpha1
   subresources:


### PR DESCRIPTION
…to save keystrokes when doing things like `kubectl get workflow`, which becomes `kubectl get wf`

Signed-off-by: jdwelch <me@jdwelch.net>