### PR TITLE
Add steps for running in cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,31 @@ You can run the operator directly from this repo like this:
 If you make changes you might need to regenerate the controller code:
 
     operator-sdk generate k8s
+
+## Deployment
+
+To run the lyra controller in cluster using the Dockerfile in the `lyraproj/lyra` repo
+
+(adapted from [the operator-sdk quick start](https://github.com/operator-framework/operator-sdk/#quick-start))
+
+```sh
+    # minikube example, reuse the docker daemon on your machine
+    # https://github.com/kubernetes/minikube/blob/0c616a6b42b28a1aab8397f5a9061f8ebbd9f3d9/README.md#reusing-the-docker-daemon
+    eval $(minikube docker-env)
+    # build the image in the lyraproj/lyra repo using e.g. docker build -t lyraproj/lyra-operator . (in that folder)
+    # verify an image has been produced (note CREATED time)
+    docker images lyraproj/lyra-operator
+    # if applicable push this to image to a public image
+    # NOTE: imagePullPolicy is set to Never (instead of Always) in operator.yaml for minikube to use the local docker daemon 
+    # create the various k8s resources, including the lyra-operator container
+    kubectl create -f deploy/service_account.yaml
+    kubectl create -f deploy/role.yaml
+    kubectl create -f deploy/role_binding.yaml
+    kubectl create -f deploy/crds/lyra_v1alpha1_workflow_crd.yaml
+    # create the operator deployment
+    kubectl create -f deploy/operator.yaml
+    # create an instance of the CRD workflow
+    kubectl apply -f deploy/crds/lyra_v1alpha1_workflow_sample.yaml
+    # check the logs on the lyra-operator pod
+    kubectl get pods | grep "lyra-operator.*1\/1" | awk '{print $1}' | xargs kubectl logs
+```

--- a/deploy/crds/lyra_v1alpha1_workflow_crd.yaml
+++ b/deploy/crds/lyra_v1alpha1_workflow_crd.yaml
@@ -42,5 +42,5 @@ spec:
               type: "string"
             refreshTime:
               type: "integer"
-              minimum: 1
-              maximum: 60  
+              minimum: 30
+              maximum: 6000

--- a/deploy/crds/lyra_v1alpha1_workflow_sample.yaml
+++ b/deploy/crds/lyra_v1alpha1_workflow_sample.yaml
@@ -8,4 +8,4 @@ spec:
     foo: kubeFooooo
     bar: kubeBaaaar
     baz: kubeBaaaaz
-  refreshTime: 10
+  refreshTime: 120

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -15,14 +15,19 @@ spec:
       serviceAccountName: lyra-operator
       containers:
         - name: lyra-operator
-          # Replace this with the built image name
-          image: lyra-operator:latest
+          image: lyraproj/lyra-operator
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "64m"
+            limits:
+              memory: "256Mi"
+              cpu: "128m"          
           ports:
           - containerPort: 60000
             name: metrics
-          command:
-          - lyra-operator
-          imagePullPolicy: Always
+          command: ["lyra", "controller", "--debug"]
+          imagePullPolicy: Never
           readinessProbe:
             exec:
               command:
@@ -41,4 +46,4 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
-              value: "lyra-operator"
+              value: lyra


### PR DESCRIPTION
Dockerfile to build `lyraproj/lyra-operator` is in https://github.com/lyraproj/lyra/pull/167 (`docker build -t lyraproj/lyra-operator .` in https://github.com/lyraproj/lyra)